### PR TITLE
Support complex connector expression filter pushdown in mongodb

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
@@ -41,7 +41,7 @@ import static java.lang.invoke.MethodHandles.lookup;
  * The value is encoded as microseconds from the 1970-01-01 00:00:00 epoch and is to be interpreted as
  * local date time without regards to any time zone.
  */
-class ShortTimestampType
+public class ShortTimestampType
         extends TimestampType
 {
     private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ShortTimestampType.class, lookup(), long.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
@@ -40,7 +40,7 @@ import static java.lang.invoke.MethodHandles.lookup;
  * <p>
  * The value is encoded as milliseconds from the 1970-01-01 00:00:00 epoch.
  */
-final class ShortTimestampWithTimeZoneType
+public final class ShortTimestampWithTimeZoneType
         extends TimestampWithTimeZoneType
 {
     private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ShortTimestampWithTimeZoneType.class, lookup(), long.class);

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -55,6 +55,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -45,6 +45,7 @@ public class MongoClientConfig
     private String requiredReplicaSetName;
     private String implicitRowFieldPrefix = "_pos";
     private boolean projectionPushDownEnabled = true;
+    private boolean complexExpressionPushdownEnabled = true;
 
     @NotNull
     public String getSchemaCollection()
@@ -249,6 +250,18 @@ public class MongoClientConfig
     public MongoClientConfig setProjectionPushdownEnabled(boolean projectionPushDownEnabled)
     {
         this.projectionPushDownEnabled = projectionPushDownEnabled;
+        return this;
+    }
+
+    public boolean isComplexExpressionPushdownEnabled()
+    {
+        return complexExpressionPushdownEnabled;
+    }
+
+    @Config("mongodb.complex-expression-pushdown.enabled")
+    public MongoClientConfig setComplexExpressionPushdownEnabled(boolean complexExpressionPushdownEnabled)
+    {
+        this.complexExpressionPushdownEnabled = complexExpressionPushdownEnabled;
         return this;
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
@@ -26,6 +26,7 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
+import io.trino.spi.type.TypeManager;
 
 import java.util.List;
 import java.util.Set;
@@ -45,6 +46,7 @@ public class MongoConnector
     private final MongoSplitManager splitManager;
     private final MongoPageSourceProvider pageSourceProvider;
     private final MongoPageSinkProvider pageSinkProvider;
+    private final TypeManager typeManager;
     private final Set<ConnectorTableFunction> connectorTableFunctions;
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -56,6 +58,7 @@ public class MongoConnector
             MongoSplitManager splitManager,
             MongoPageSourceProvider pageSourceProvider,
             MongoPageSinkProvider pageSinkProvider,
+            TypeManager typeManager,
             Set<ConnectorTableFunction> connectorTableFunctions,
             Set<SessionPropertiesProvider> sessionPropertiesProviders)
     {
@@ -63,6 +66,7 @@ public class MongoConnector
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.connectorTableFunctions = ImmutableSet.copyOf(requireNonNull(connectorTableFunctions, "connectorTableFunctions is null"));
         this.sessionProperties = sessionPropertiesProviders.stream()
                 .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
@@ -74,7 +78,7 @@ public class MongoConnector
     {
         checkConnectorSupports(READ_UNCOMMITTED, isolationLevel);
         MongoTransactionHandle transaction = new MongoTransactionHandle();
-        transactions.put(transaction, new MongoMetadata(mongoSession));
+        transactions.put(transaction, new MongoMetadata(mongoSession, typeManager));
         return transaction;
     }
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -23,6 +23,8 @@ import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.plugin.base.projection.ApplyProjectionUtil;
 import io.trino.plugin.mongodb.MongoIndex.MongodbIndexKey;
+import io.trino.plugin.mongodb.expression.MongoConnectorExpressionRewriterBuilder;
+import io.trino.plugin.mongodb.expression.MongoExpression;
 import io.trino.plugin.mongodb.ptf.Query.QueryFunctionHandle;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.Assignment;
@@ -49,7 +51,9 @@ import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortingProperty;
 import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.FieldDereference;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
@@ -64,6 +68,7 @@ import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.RowType.Field;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
 import org.bson.Document;
 
@@ -91,12 +96,15 @@ import static com.mongodb.client.model.Aggregates.project;
 import static com.mongodb.client.model.Filters.ne;
 import static com.mongodb.client.model.Projections.exclude;
 import static io.trino.plugin.base.TemporaryTables.generateTemporaryTableName;
+import static io.trino.plugin.base.expression.ConnectorExpressions.and;
+import static io.trino.plugin.base.expression.ConnectorExpressions.extractConjuncts;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.ProjectedColumnRepresentation;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.mongodb.MongoSession.COLLECTION_NAME;
 import static io.trino.plugin.mongodb.MongoSession.DATABASE_NAME;
 import static io.trino.plugin.mongodb.MongoSession.ID;
+import static io.trino.plugin.mongodb.MongoSessionProperties.isComplexExpressionPushdown;
 import static io.trino.plugin.mongodb.MongoSessionProperties.isProjectionPushdownEnabled;
 import static io.trino.plugin.mongodb.TypeUtils.isPushdownSupportedType;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -125,12 +133,14 @@ public class MongoMetadata
     private static final int MAX_QUALIFIED_IDENTIFIER_BYTE_LENGTH = 120;
 
     private final MongoSession mongoSession;
+    private final TypeManager typeManager;
 
     private final AtomicReference<Runnable> rollbackAction = new AtomicReference<>();
 
-    public MongoMetadata(MongoSession mongoSession)
+    public MongoMetadata(MongoSession mongoSession, TypeManager typeManager)
     {
         this.mongoSession = requireNonNull(mongoSession, "mongoSession is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
     @Override
@@ -580,6 +590,7 @@ public class MongoMetadata
                         handle.getRemoteTableName(),
                         handle.getFilter(),
                         handle.getConstraint(),
+                        handle.getConstraintExpressions(),
                         handle.getProjectedColumns(),
                         OptionalInt.of(toIntExact(limit))),
                 true,
@@ -593,9 +604,14 @@ public class MongoMetadata
 
         TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
         TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary());
+        List<String> newConstraintExpressions;
         TupleDomain<ColumnHandle> remainingFilter;
+        Optional<ConnectorExpression> remainingExpression;
+
         if (newDomain.isNone()) {
+            newConstraintExpressions = ImmutableList.of();
             remainingFilter = TupleDomain.all();
+            remainingExpression = Optional.of(Constant.TRUE);
         }
         else {
             Map<ColumnHandle, Domain> domains = newDomain.getDomains().orElseThrow();
@@ -617,9 +633,37 @@ public class MongoMetadata
             }
             newDomain = TupleDomain.withColumnDomains(supported);
             remainingFilter = TupleDomain.withColumnDomains(unsupported);
+
+            if (isComplexExpressionPushdown(session)) {
+                ImmutableList.Builder<String> newExpressions = ImmutableList.builder();
+                ImmutableList.Builder<ConnectorExpression> remainingExpressions = ImmutableList.builder();
+                for (ConnectorExpression expression : extractConjuncts(constraint.getExpression())) {
+                    if (expression instanceof Call) {
+                        Optional<MongoExpression> converted = convertPredicate(session, expression, constraint.getAssignments());
+                        if (converted.isPresent()) {
+                            Optional<Document> expressionDocument = converted.get().expressionDocument();
+                            checkArgument(expressionDocument.isPresent(), "expressionDocument is empty");
+                            newExpressions.add(expressionDocument.get().toJson());
+                        }
+                        else {
+                            remainingExpressions.add(expression);
+                        }
+                    }
+                }
+                newConstraintExpressions = ImmutableSet.<String>builder()
+                        .addAll(handle.getConstraintExpressions())
+                        .addAll(newExpressions.build())
+                        .build().asList();
+                remainingExpression = Optional.of(and(remainingExpressions.build()));
+            }
+            else {
+                newConstraintExpressions = ImmutableList.of();
+                remainingExpression = Optional.empty();
+            }
         }
 
-        if (oldDomain.equals(newDomain)) {
+        if (oldDomain.equals(newDomain)
+                && handle.getConstraintExpressions().equals(newConstraintExpressions)) {
             return Optional.empty();
         }
 
@@ -628,10 +672,21 @@ public class MongoMetadata
                 handle.getRemoteTableName(),
                 handle.getFilter(),
                 newDomain,
+                newConstraintExpressions,
                 handle.getProjectedColumns(),
                 handle.getLimit());
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, false));
+        return Optional.of(
+                remainingExpression.isPresent()
+                        ? new ConstraintApplicationResult<>(handle, remainingFilter, remainingExpression.get(), false)
+                        : new ConstraintApplicationResult<>(handle, remainingFilter, false));
+    }
+
+    private Optional<MongoExpression> convertPredicate(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return MongoConnectorExpressionRewriterBuilder.newBuilder()
+                .addRules(typeManager).build()
+                .rewrite(session, expression, assignments);
     }
 
     @Override

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -140,6 +140,8 @@ public class MongoSession
     private static final String LTE_OP = "$lte";
     private static final String IN_OP = "$in";
 
+    private static final String EXPR = "$expr";
+
     public static final String DATABASE_NAME = "databaseName";
     public static final String COLLECTION_NAME = "collectionName";
     public static final String ID = "id";
@@ -560,8 +562,20 @@ public class MongoSession
         // Use $and operator because Document.putAll method overwrites existing entries where the key already exists
         ImmutableList.Builder<Document> filter = ImmutableList.builder();
         table.getFilter().ifPresent(json -> filter.add(parseFilter(json)));
+        filter.add(buildFilterExpression(table.getConstraintExpressions()));
         filter.add(buildQuery(table.getConstraint()));
         return andPredicate(filter.build());
+    }
+
+    static Document buildFilterExpression(List<String> constraintExpression)
+    {
+        ImmutableList.Builder<Document> expressionFilterBuilder = ImmutableList.builder();
+        constraintExpression.forEach(json -> expressionFilterBuilder.add(parseFilter(json)));
+        List<Document> filterExpression = expressionFilterBuilder.build();
+        if (!filterExpression.isEmpty()) {
+            return documentOf(EXPR, andPredicate(filterExpression));
+        }
+        return new Document();
     }
 
     @VisibleForTesting

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
@@ -27,6 +27,7 @@ public final class MongoSessionProperties
         implements SessionPropertiesProvider
 {
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
+    private static final String COMPLEX_EXPRESSION_PUSHDOWN_ENABLED = "complex_expression_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -38,6 +39,11 @@ public final class MongoSessionProperties
                         PROJECTION_PUSHDOWN_ENABLED,
                         "Read only required fields from a row type",
                         mongoConfig.isProjectionPushdownEnabled(),
+                        false))
+                .add(booleanProperty(
+                        COMPLEX_EXPRESSION_PUSHDOWN_ENABLED,
+                        "Allow complex expression pushdown into connectors",
+                        mongoConfig.isComplexExpressionPushdownEnabled(),
                         false))
                 .build();
     }
@@ -51,5 +57,10 @@ public final class MongoSessionProperties
     public static boolean isProjectionPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isComplexExpressionPushdown(ConnectorSession session)
+    {
+        return session.getProperty(COMPLEX_EXPRESSION_PUSHDOWN_ENABLED, Boolean.class);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
@@ -15,12 +15,14 @@ package io.trino.plugin.mongodb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -36,12 +38,13 @@ public class MongoTableHandle
     private final RemoteTableName remoteTableName;
     private final Optional<String> filter;
     private final TupleDomain<ColumnHandle> constraint;
+    private final List<String> constraintExpressions;
     private final Set<MongoColumnHandle> projectedColumns;
     private final OptionalInt limit;
 
     public MongoTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, Optional<String> filter)
     {
-        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableSet.of(), OptionalInt.empty());
+        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableList.of(), ImmutableSet.of(), OptionalInt.empty());
     }
 
     @JsonCreator
@@ -50,6 +53,7 @@ public class MongoTableHandle
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("filter") Optional<String> filter,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
+            @JsonProperty("constraintExpressions") List<String> constraintExpressions,
             @JsonProperty("projectedColumns") Set<MongoColumnHandle> projectedColumns,
             @JsonProperty("limit") OptionalInt limit)
     {
@@ -57,6 +61,7 @@ public class MongoTableHandle
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.filter = requireNonNull(filter, "filter is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
+        this.constraintExpressions = requireNonNull(constraintExpressions, "constraintExpressions is null");
         this.projectedColumns = ImmutableSet.copyOf(requireNonNull(projectedColumns, "projectedColumns is null"));
         this.limit = requireNonNull(limit, "limit is null");
     }
@@ -86,6 +91,12 @@ public class MongoTableHandle
     }
 
     @JsonProperty
+    public List<String> getConstraintExpressions()
+    {
+        return constraintExpressions;
+    }
+
+    @JsonProperty
     public Set<MongoColumnHandle> getProjectedColumns()
     {
         return projectedColumns;
@@ -104,6 +115,7 @@ public class MongoTableHandle
                 remoteTableName,
                 filter,
                 constraint,
+                constraintExpressions,
                 projectedColumns,
                 limit);
     }
@@ -111,7 +123,7 @@ public class MongoTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaTableName, filter, constraint, projectedColumns, limit);
+        return Objects.hash(schemaTableName, filter, constraint, constraintExpressions, projectedColumns, limit);
     }
 
     @Override
@@ -128,6 +140,7 @@ public class MongoTableHandle
                 Objects.equals(this.remoteTableName, other.remoteTableName) &&
                 Objects.equals(this.filter, other.filter) &&
                 Objects.equals(this.constraint, other.constraint) &&
+                Objects.equals(this.constraintExpressions, other.constraintExpressions) &&
                 Objects.equals(this.projectedColumns, other.projectedColumns) &&
                 Objects.equals(this.limit, other.limit);
     }
@@ -140,6 +153,7 @@ public class MongoTableHandle
                 .add("remoteTableName", remoteTableName)
                 .add("filter", filter)
                 .add("constraint", constraint)
+                .add("constraintExpressions", constraintExpressions)
                 .add("projectedColumns", projectedColumns)
                 .add("limit", limit)
                 .toString();

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ExpressionUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ExpressionUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import org.bson.Document;
+
+import java.util.Base64;
+
+public class ExpressionUtils
+{
+    private ExpressionUtils() {}
+
+    public static Document toDecimal(Object value)
+    {
+        return documentOf("$toDecimal", value);
+    }
+
+    public static Document toDate(Object value)
+    {
+        return documentOf("$toDate", value);
+    }
+
+    public static Document toObjectId(Object value)
+    {
+        return documentOf("$toObjectId", value);
+    }
+
+    public static Document toBinary(byte[] value)
+    {
+        return documentOf("$binary", documentOf("base64", Base64.getEncoder().encodeToString(value)).append("subType", "00"));
+    }
+
+    public static Document toString(Object value)
+    {
+        Document convertValue = documentOf("input", value)
+                .append("to", "string")
+                .append("onError", null);
+        return documentOf("$convert", convertValue);
+    }
+
+    public static Document documentOf(String key, Object value)
+    {
+        return new Document(key, value);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/JsonObjectExpressionBuilder.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/JsonObjectExpressionBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import org.bson.Document;
+
+import java.util.List;
+
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+
+public class JsonObjectExpressionBuilder
+{
+    private final String json;
+    private final List<String> jsonPath;
+    private static int variableCount;
+
+    public JsonObjectExpressionBuilder(String json, List<String> jsonPath)
+    {
+        this.json = requireNonNull(json, "json is null");
+        this.jsonPath = requireNonNull(jsonPath, "jsonPath is null");
+    }
+
+    public Document build()
+    {
+        return buildExpression("$" + json, jsonPath);
+    }
+
+    private static Document buildExpression(String variable, List<String> jsonPath)
+    {
+        StringBuilder variableBuilder = new StringBuilder(variable);
+        for (int i = 0; i < jsonPath.size(); i++) {
+            String path = jsonPath.get(i);
+            if (isInteger(path)) {
+                String letVariable = newVariable();
+                Document inExpr = inExpression(letVariable, jsonPath.subList(i + 1, jsonPath.size()));
+                return letExpression(letVariable, variableBuilder.toString(), Integer.parseInt(path), inExpr);
+            }
+            else {
+                variableBuilder.append(".").append(path);
+            }
+        }
+        return ExpressionUtils.toString(variableBuilder.toString());
+    }
+
+    private static Document inExpression(String letVariable, List<String> path)
+    {
+        return buildExpression("$$" + letVariable, path);
+    }
+
+    private static Document letExpression(String letVariable, String variable, int index, Document inExpression)
+    {
+        Document letValue = documentOf("vars", documentOf(letVariable, arrayObjectConditionExpression(variable, index)))
+                .append("in", inExpression);
+        return documentOf("$let", letValue);
+    }
+
+    private static Document arrayObjectConditionExpression(String variable, int index)
+    {
+        return documentOf("$cond", asList(arrayCheck(variable), arrayElemAt(variable, index), objectElement(variable, index)));
+    }
+
+    private static Document arrayCheck(String variable)
+    {
+        Document type = documentOf("$type", variable);
+        return documentOf("$eq", asList(type, "array"));
+    }
+
+    private static Document arrayElemAt(String variable, int index)
+    {
+        return documentOf("$arrayElemAt", asList(variable, index));
+    }
+
+    private static String objectElement(String variable, int index)
+    {
+        return "%s.%d".formatted(variable, index);
+    }
+
+    private static String newVariable()
+    {
+        return "var_%05d".formatted(variableCount++);
+    }
+
+    private static boolean isInteger(String value)
+    {
+        try {
+            Integer.parseInt(value);
+            return true;
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeSignature;
+
+import static io.trino.spi.type.StandardTypes.JSON;
+
+public class MongoConnectorExpressionRewriterBuilder
+{
+    public static MongoConnectorExpressionRewriterBuilder newBuilder()
+    {
+        return new MongoConnectorExpressionRewriterBuilder();
+    }
+
+    private final ImmutableSet.Builder<ConnectorExpressionRule<?, MongoExpression>> rules = ImmutableSet.builder();
+
+    private MongoConnectorExpressionRewriterBuilder() {}
+
+    public MongoConnectorExpressionRewriterBuilder addRules(TypeManager typeManager)
+    {
+        add(new RewriteVariable());
+        add(new RewriteBooleanConstant());
+        add(new RewriteVarcharConstant());
+        add(new RewriteVarbinaryConstant());
+        add(new RewriteExactNumericConstant());
+        add(new RewriteObjectIdConstant());
+        add(new RewriteDateTimeConstant());
+        add(new RewriteAnd());
+        add(new RewriteOr());
+        add(new RewriteComparison());
+        add(new RewriteIn());
+        add(new RewriteNot());
+        add(new RewriteIsNull());
+        add(new RewriteJsonConstant(typeManager.getType(new TypeSignature(JSON))));
+        add(new RewriteJsonPath(typeManager.getType(new TypeSignature("JsonPath"))));
+        add(new RewriteJsonExtractScalar());
+        add(new RewriteFromIso8601Date());
+        add(new RewriteFromIso8601Timestamp());
+
+        return this;
+    }
+
+    public MongoConnectorExpressionRewriterBuilder add(ConnectorExpressionRule<?, MongoExpression> rule)
+    {
+        rules.add(rule);
+        return this;
+    }
+
+    public ConnectorExpressionRewriter<MongoExpression> build()
+    {
+        return new ConnectorExpressionRewriter<>(rules.build());
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoExpression.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoExpression.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import org.bson.Document;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record MongoExpression(Object expression)
+{
+    public MongoExpression
+    {
+        requireNonNull(expression, "expression is null");
+    }
+
+    public Optional<Document> expressionDocument()
+    {
+        if (expression instanceof Document document) {
+            return Optional.of(document);
+        }
+        return Optional.empty();
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteAnd.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteAnd.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
+
+public class RewriteAnd
+        extends RewriteLogicalExpression
+{
+    public RewriteAnd()
+    {
+        super(AND_FUNCTION_NAME, "$and");
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteBooleanConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteBooleanConstant.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.BooleanType;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+
+public class RewriteBooleanConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(BooleanType.class::isInstance));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Boolean value = (Boolean) constant.getValue();
+        return Optional.of(new MongoExpression(value));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteComparison.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteComparison.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Verify.verifyNotNull;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.NOT_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+public class RewriteComparison
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private static final Capture<ConnectorExpression> LEFT = newCapture();
+    private static final Capture<ConnectorExpression> RIGHT = newCapture();
+
+    public enum ComparisonOperator
+    {
+        EQUAL(EQUAL_OPERATOR_FUNCTION_NAME, "$eq"),
+        NOT_EQUAL(NOT_EQUAL_OPERATOR_FUNCTION_NAME, "$ne"),
+        LESS_THAN(LESS_THAN_OPERATOR_FUNCTION_NAME, "$lt"),
+        LESS_THAN_OR_EQUAL(LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, "$lte"),
+        GREATER_THAN(GREATER_THAN_OPERATOR_FUNCTION_NAME, "$gt"),
+        GREATER_THAN_OR_EQUAL(GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, "$gte"),
+        /**/;
+
+        private final FunctionName functionName;
+        private final String operator;
+
+        private static final Map<FunctionName, ComparisonOperator> OPERATOR_BY_FUNCTION_NAME = Stream.of(values())
+                .collect(toImmutableMap(ComparisonOperator::getFunctionName, identity()));
+
+        ComparisonOperator(FunctionName functionName, String operator)
+        {
+            this.functionName = requireNonNull(functionName, "functionName is null");
+            this.operator = requireNonNull(operator, "operator is null");
+        }
+
+        private FunctionName getFunctionName()
+        {
+            return functionName;
+        }
+
+        private String getOperator()
+        {
+            return operator;
+        }
+
+        private static ComparisonOperator forFunctionName(FunctionName functionName)
+        {
+            return verifyNotNull(OPERATOR_BY_FUNCTION_NAME.get(functionName), "Function name not recognized: %s", functionName);
+        }
+    }
+
+    private final Pattern<Call> pattern;
+
+    public RewriteComparison()
+    {
+        Set<FunctionName> functionNames = Arrays.stream(ComparisonOperator.values())
+                .map(ComparisonOperator::getFunctionName)
+                .collect(toImmutableSet());
+
+        pattern = call()
+                .with(functionName().matching(functionNames::contains))
+                .with(type().equalTo(BOOLEAN))
+                .with(argumentCount().equalTo(2))
+                .with(argument(0).matching(expression().capturedAs(LEFT)))
+                .with(argument(1).matching(expression().capturedAs(RIGHT)));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Optional<MongoExpression> left = context.defaultRewrite(captures.get(LEFT));
+        if (left.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<MongoExpression> right = context.defaultRewrite(captures.get(RIGHT));
+        if (right.isEmpty()) {
+            return Optional.empty();
+        }
+        verify(call.getFunctionName().getCatalogSchema().isEmpty()); // filtered out by the pattern
+        Object leftValue = left.get().expression();
+        Object rightValue = right.get().expression();
+
+        ComparisonOperator operator = ComparisonOperator.forFunctionName(call.getFunctionName());
+        if (captures.get(LEFT) instanceof Variable) {
+            leftValue = "$" + leftValue;
+        }
+        if (captures.get(RIGHT) instanceof Variable) {
+            rightValue = "$" + rightValue;
+        }
+        return Optional.of(new MongoExpression(documentOf(operator.getOperator(), Arrays.asList(leftValue, rightValue))));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteDateTimeConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteDateTimeConstant.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.ShortTimestampType;
+import io.trino.spi.type.ShortTimestampWithTimeZoneType;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.Type;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDate;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.roundDiv;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.time.ZoneOffset.UTC;
+
+public class RewriteDateTimeConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(
+            type -> type instanceof TimeType || type instanceof DateType || type instanceof ShortTimestampType || type instanceof ShortTimestampWithTimeZoneType));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Object value = constant.getValue();
+        Type type = constant.getType();
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        if (type instanceof TimeType) {
+            long picos = (long) value;
+            Instant instant = Instant.ofEpochSecond(0, LocalTime.ofNanoOfDay(roundDiv(picos, PICOSECONDS_PER_NANOSECOND)).toNanoOfDay());
+            return Optional.of(new MongoExpression(toDate(instant.toString())));
+        }
+
+        if (type instanceof DateType) {
+            long days = (long) value;
+            return Optional.of(new MongoExpression(toDate(LocalDate.ofEpochDay(days).toString())));
+        }
+
+        if (type instanceof ShortTimestampType) {
+            long epochMicros = (long) value;
+            long epochSecond = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+            int nanoFraction = floorMod(epochMicros, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
+            Instant instant = Instant.ofEpochSecond(epochSecond, nanoFraction);
+            return Optional.of(new MongoExpression(toDate(LocalDateTime.ofInstant(instant, UTC).toString())));
+        }
+
+        if (type instanceof ShortTimestampWithTimeZoneType) {
+            long millisUtc = unpackMillisUtc((long) value);
+            Instant instant = Instant.ofEpochMilli(millisUtc);
+            return Optional.of(new MongoExpression(toDate(LocalDateTime.ofInstant(instant, UTC).toString())));
+        }
+
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteExactNumericConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteExactNumericConstant.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDecimal;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+
+public class RewriteExactNumericConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(type ->
+            type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT || type instanceof DecimalType));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Type type = constant.getType();
+        Object value = constant.getValue();
+        if (value == null) {
+            return Optional.empty();
+        }
+        if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT) {
+            return Optional.of(new MongoExpression(constant.getValue()));
+        }
+
+        if (type instanceof DecimalType decimalType) {
+            if (decimalType.isShort()) {
+                return Optional.of(new MongoExpression(toDecimal(Decimals.toString((long) value, decimalType.getScale()))));
+            }
+            return Optional.of(new MongoExpression(toDecimal(Decimals.toString((Int128) value, decimalType.getScale()))));
+        }
+        // TODO support REAL and DOUBLE
+
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Conversion.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Conversion.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDate;
+
+public class RewriteFromIso8601Conversion
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private static final Capture<ConnectorExpression> VALUE = newCapture();
+
+    private final Pattern<Call> pattern;
+
+    public RewriteFromIso8601Conversion(FunctionName functionName, Predicate<? super Type> typeMatchingPredicate)
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(functionName))
+                .with(type().matching(typeMatchingPredicate))
+                .with(argumentCount().equalTo(1))
+                .with(argument(0).matching(expression().capturedAs(VALUE)));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Optional<MongoExpression> value = context.defaultRewrite(captures.get(VALUE));
+        return value.map(mongoExpression -> new MongoExpression(toDate(mongoExpression.expression())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Date.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Date.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.DateType;
+
+public class RewriteFromIso8601Date
+        extends RewriteFromIso8601Conversion
+{
+    public RewriteFromIso8601Date()
+    {
+        super(new FunctionName("from_iso8601_date"), DateType.class::isInstance);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Timestamp.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Timestamp.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.ShortTimestampWithTimeZoneType;
+
+public class RewriteFromIso8601Timestamp
+        extends RewriteFromIso8601Conversion
+{
+    public RewriteFromIso8601Timestamp()
+    {
+        super(new FunctionName("from_iso8601_timestamp"), ShortTimestampWithTimeZoneType.class::isInstance);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIn.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIn.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.arguments;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.spi.expression.StandardFunctions.ARRAY_CONSTRUCTOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class RewriteIn
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private static final Capture<ConnectorExpression> VALUE = newCapture();
+    private static final Capture<List<ConnectorExpression>> EXPRESSIONS = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(IN_PREDICATE_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(2))
+            .with(argument(0).matching(expression().capturedAs(VALUE)))
+            .with(argument(1).matching(call().with(functionName().equalTo(ARRAY_CONSTRUCTOR_FUNCTION_NAME)).with(arguments().capturedAs(EXPRESSIONS))));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Optional<MongoExpression> value = context.defaultRewrite(captures.get(VALUE));
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<ConnectorExpression> expressions = captures.get(EXPRESSIONS);
+
+        ImmutableList.Builder<Object> rewrittenValues = ImmutableList.builderWithExpectedSize(expressions.size());
+        for (ConnectorExpression expression : expressions) {
+            Optional<MongoExpression> rewritten = context.defaultRewrite(expression);
+            if (rewritten.isEmpty()) {
+                return Optional.empty();
+            }
+            rewrittenValues.add(rewritten.get().expression());
+        }
+        List<Object> values = rewrittenValues.build();
+        verify(!values.isEmpty(), "values is empty");
+
+        return Optional.of(new MongoExpression(documentOf("$in", Arrays.asList(value.get().expression(), values))));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIsNull.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIsNull.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.BooleanType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
+
+public class RewriteIsNull
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private final Pattern<Call> pattern;
+
+    public RewriteIsNull()
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(IS_NULL_FUNCTION_NAME))
+                .with(type().matching(BooleanType.class::isInstance))
+                .with(argumentCount().equalTo(1));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        Optional<MongoExpression> rewritten = context.defaultRewrite(arguments.get(0));
+        if (rewritten.isEmpty()) {
+            return Optional.empty();
+        }
+        Object value = rewritten.get().expression();
+        if (arguments.get(0) instanceof Variable) {
+            value = "$" + value;
+        }
+        return Optional.of(new MongoExpression(documentOf("$eq", Arrays.asList(value, null))));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonConstant.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.airlift.slice.Slice;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+
+public class RewriteJsonConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private final Pattern<Constant> pattern;
+
+    public RewriteJsonConstant(Type jsonType)
+    {
+        this.pattern = constant().with(type().matching(jsonType.getClass()::isInstance));
+    }
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        if (constant.getValue() == null) {
+            return Optional.empty();
+        }
+        Slice slice = (Slice) constant.getValue();
+        if (slice == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new MongoExpression(slice.toStringUtf8()));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonExtractScalar.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonExtractScalar.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.VarcharType;
+import org.bson.Document;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+
+public class RewriteJsonExtractScalar
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private static final Capture<ConnectorExpression> VALUE = newCapture();
+    private static final Capture<ConnectorExpression> JSON_PATH = newCapture();
+
+    private final Pattern<Call> pattern;
+
+    public RewriteJsonExtractScalar()
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(new FunctionName("json_extract_scalar")))
+                .with(type().matching(VarcharType.class::isInstance))
+                .with(argumentCount().equalTo(2))
+                .with(argument(0).matching(expression().capturedAs(VALUE)))
+                // this only captures cases where the JSON_PATH is a literal and no CAST is involved
+                .with(argument(1).matching(expression().capturedAs(JSON_PATH)));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Optional<MongoExpression> value = context.defaultRewrite(captures.get(VALUE));
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<MongoExpression> jsonPath = context.defaultRewrite(captures.get(JSON_PATH));
+        if (jsonPath.isEmpty()) {
+            return Optional.empty();
+        }
+        String jsonPathString = (String) jsonPath.get().expression();
+
+        if (jsonPathString.endsWith("[\"$date\"]")) {
+            // { "dateCreated": { "$date": "2003-03-26" } }
+            // $date field will be accessible with parent object name
+            jsonPathString = jsonPathString.replace("[\"$date\"]", "");
+        }
+
+        String jsonColName = (String) value.get().expression();
+        List<String> jsonPathSplits = Arrays.stream(jsonPathString.split("\\."))
+                .toList();
+
+        Document jsonObjectExpression = new JsonObjectExpressionBuilder(jsonColName, jsonPathSplits)
+                .build();
+
+        return Optional.of(new MongoExpression(jsonObjectExpression));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonPath.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonPath.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+
+public class RewriteJsonPath
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private final Pattern<Constant> pattern;
+
+    public RewriteJsonPath(Type jsonPathType)
+    {
+        this.pattern = constant().with(type().matching(jsonPathType.getClass()::isInstance));
+    }
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        if (constant.getValue() == null) {
+            return Optional.empty();
+        }
+        String jsonPath = constant.getValue().toString();
+        if (jsonPath == null) {
+            return Optional.empty();
+        }
+        if (jsonPath.startsWith("$.")) {
+            jsonPath = jsonPath.substring("$.".length());
+        }
+        return Optional.of(new MongoExpression(jsonPath));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteLogicalExpression.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteLogicalExpression.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Objects.requireNonNull;
+
+class RewriteLogicalExpression
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private final Pattern<Call> pattern;
+    private final String operator;
+
+    RewriteLogicalExpression(FunctionName functionName, String operator)
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(requireNonNull(functionName, "functionName is null")))
+                .with(type().equalTo(BOOLEAN));
+        this.operator = requireNonNull(operator, "operator is null");
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        verify(!arguments.isEmpty(), "no arguments");
+        ImmutableList.Builder<Object> terms = ImmutableList.builder();
+        for (ConnectorExpression argument : arguments) {
+            verify(argument.getType() == BOOLEAN, "Unexpected type of argument: %s", argument.getType());
+            Optional<MongoExpression> rewritten = context.defaultRewrite(argument);
+            if (rewritten.isEmpty()) {
+                return Optional.empty();
+            }
+            terms.add(rewritten.get().expression());
+        }
+        return Optional.of(new MongoExpression(documentOf(operator, terms.build())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteNot.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteNot.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.BooleanType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.spi.expression.StandardFunctions.NOT_FUNCTION_NAME;
+
+public class RewriteNot
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private final Pattern<Call> pattern;
+
+    public RewriteNot()
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(NOT_FUNCTION_NAME))
+                .with(type().matching(BooleanType.class::isInstance))
+                .with(argumentCount().equalTo(1));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+
+        Optional<MongoExpression> rewritten = context.defaultRewrite(arguments.get(0));
+        if (rewritten.isEmpty()) {
+            return Optional.empty();
+        }
+        Object value = rewritten.get().expression();
+        if (arguments.get(0) instanceof Variable) {
+            value = "$" + value;
+        }
+        return Optional.of(new MongoExpression(documentOf("$not", Arrays.asList(value))));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteObjectIdConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteObjectIdConstant.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.airlift.slice.Slice;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.plugin.mongodb.ObjectIdType;
+import io.trino.spi.expression.Constant;
+import org.bson.types.ObjectId;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toObjectId;
+
+public class RewriteObjectIdConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(ObjectIdType.class::isInstance));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Slice slice = (Slice) constant.getValue();
+        if (slice == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new MongoExpression(toObjectId(new ObjectId((slice).getBytes()).toString())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteOr.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteOr.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import static io.trino.spi.expression.StandardFunctions.OR_FUNCTION_NAME;
+
+public class RewriteOr
+        extends RewriteLogicalExpression
+{
+    public RewriteOr()
+    {
+        super(OR_FUNCTION_NAME, "$or");
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVarbinaryConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVarbinaryConstant.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.airlift.slice.Slice;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.VarbinaryType;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toBinary;
+
+public class RewriteVarbinaryConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(VarbinaryType.class::isInstance));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Slice slice = (Slice) constant.getValue();
+        if (slice == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new MongoExpression(toBinary(slice.getBytes())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVarcharConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVarcharConstant.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.airlift.slice.Slice;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.spi.type.Chars.padSpaces;
+
+public class RewriteVarcharConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(type -> type instanceof VarcharType || type instanceof CharType));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Slice slice = (Slice) constant.getValue();
+        Type type = constant.getType();
+        if (slice == null) {
+            return Optional.empty();
+        }
+        if (type instanceof CharType charType) {
+            slice = padSpaces(slice, charType);
+        }
+        return Optional.of(new MongoExpression(slice.toStringUtf8()));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVariable.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVariable.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.plugin.mongodb.MongoColumnHandle;
+import io.trino.spi.expression.Variable;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+
+public class RewriteVariable
+        implements ConnectorExpressionRule<Variable, MongoExpression>
+{
+    @Override
+    public Pattern<Variable> getPattern()
+    {
+        return variable();
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Variable variable, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        MongoColumnHandle columnHandle = (MongoColumnHandle) context.getAssignment(variable.getName());
+        return Optional.of(new MongoExpression(columnHandle.getQualifiedName()));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ptf/Query.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ptf/Query.java
@@ -41,6 +41,7 @@ import io.trino.spi.function.table.Descriptor;
 import io.trino.spi.function.table.ScalarArgument;
 import io.trino.spi.function.table.ScalarArgumentSpecification;
 import io.trino.spi.function.table.TableFunctionAnalysis;
+import io.trino.spi.type.TypeManager;
 import org.bson.Document;
 import org.bson.json.JsonParseException;
 
@@ -65,10 +66,11 @@ public class Query
     private final MongoSession session;
 
     @Inject
-    public Query(MongoSession session)
+    public Query(MongoSession session, TypeManager typeManager)
     {
         requireNonNull(session, "session is null");
-        this.metadata = new MongoMetadata(session);
+        requireNonNull(typeManager, "typeManager is null");
+        this.metadata = new MongoMetadata(session, typeManager);
         this.session = session;
     }
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
@@ -43,7 +43,8 @@ public class TestMongoClientConfig
                 .setWriteConcern(WriteConcernType.ACKNOWLEDGED)
                 .setRequiredReplicaSetName(null)
                 .setImplicitRowFieldPrefix("_pos")
-                .setProjectionPushdownEnabled(true));
+                .setProjectionPushdownEnabled(true)
+                .setComplexExpressionPushdownEnabled(true));
     }
 
     @Test
@@ -67,6 +68,7 @@ public class TestMongoClientConfig
                 .put("mongodb.required-replica-set", "replica_set")
                 .put("mongodb.implicit-row-field-prefix", "_prefix")
                 .put("mongodb.projection-pushdown-enabled", "false")
+                .put("mongodb.complex-expression-pushdown.enabled", "false")
                 .buildOrThrow();
 
         MongoClientConfig expected = new MongoClientConfig()
@@ -85,7 +87,8 @@ public class TestMongoClientConfig
                 .setWriteConcern(WriteConcernType.UNACKNOWLEDGED)
                 .setRequiredReplicaSetName("replica_set")
                 .setImplicitRowFieldPrefix("_prefix")
-                .setProjectionPushdownEnabled(false);
+                .setProjectionPushdownEnabled(false)
+                .setComplexExpressionPushdownEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
@@ -122,6 +122,7 @@ public class TestMongoTableHandle
                 remoteTableName,
                 Optional.empty(),
                 TupleDomain.all(),
+                ImmutableList.of(),
                 projectedColumns,
                 OptionalInt.empty());
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR covers use cases for connector expression Filter pushdown:

- Complex Filter which can not represent by TupleDomain
- `json_extract_scalar`
- `from_iso8601_timestamp`
- `from_iso8601_date`

Covered Logical operator:

- `OR`, `AND`

Covered Comparision Operator:

- `=`, `!=`, `<`, `>`, `>=`, `<=`

Other Operators:

- `IN`
- `IS NULL`
- `IS NOT NULL`

Covered Type:

- `BooleanType`
- `ObjectIdType`
- `CharType`, `VarcharType`, `VarbinaryType`
- `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `DecimalType`
- `TimeType`, `DateType`, `ShortTimestampType`, `ShortTimestampWithTimeZoneType`



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
